### PR TITLE
ASDPLNG-142: Move IDDS systems to be managed by asd-pup

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,30 @@ include profile_idds
 
 The following parameters need to be set in hiera:
 ```
-...tbd...
+profile_idds::firewall::firewall_hash:
+  allowed_db:
+    NAME: "postgres"
+    PORT: "5432"
+    Example subnet: "141.142.100.1/24"
+  allowed_usaged:
+    NAME: "usaged"
+    PORT: "7703"
+    Example subnet: "141.142.100.1/24"
+  allowed_secure_web:
+    NAME: "https"
+    PORT: "443"
+    Example subnet: "141.142.100.1/24"
+  allowed_web:
+    NAME: "http"
+    PORT: "80"
+    Example subnet: "141.142.100.1/24"
+
+profile_idds::ssh::acctd_subnets:
+  - "141.142.100.1/24"  # Example subnet
 ```
 
 ## Dependencies
-- tbd
+n/a
 
 ## Reference
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -7,9 +7,14 @@
 ### Classes
 
 * [`profile_idds`](#profile_idds): Configure IDDS services, etc
-* [`profile_idds::firewall`](#profile_iddsfirewall)
+* [`profile_idds::firewall`](#profile_iddsfirewall): Set up the firewall for the server
 * [`profile_idds::services`](#profile_iddsservices): Configure IDDS services
+* [`profile_idds::ssh`](#profile_iddsssh): Allow ssh for service type accounts
 * [`profile_idds::users`](#profile_iddsusers): Configure IDDS service users
+
+### Functions
+
+* [`profile_idds::add_firewall_entries`](#profile_iddsadd_firewall_entries)
 
 ## Classes
 
@@ -27,7 +32,15 @@ include profile_idds
 
 ### <a name="profile_iddsfirewall"></a>`profile_idds::firewall`
 
-The profile_idds::firewall class.
+Set up the firewall for the server
+
+#### Examples
+
+##### 
+
+```puppet
+include profile_idds::firewall
+```
 
 #### Parameters
 
@@ -39,7 +52,8 @@ The following parameters are available in the `profile_idds::firewall` class:
 
 Data type: `Hash`
 
-
+The parameter is a hash of hashes.
+Each contained hash should start with 2 entries: "NAME' and 'PORT'.
 
 ### <a name="profile_iddsservices"></a>`profile_idds::services`
 
@@ -53,6 +67,65 @@ Configure IDDS services
 include profile_idds::services
 ```
 
+### <a name="profile_iddsssh"></a>`profile_idds::ssh`
+
+Allow ssh for service type accounts
+
+#### Examples
+
+##### 
+
+```puppet
+include profile_idds::ssh
+```
+
+#### Parameters
+
+The following parameters are available in the `profile_idds::ssh` class:
+
+* [`acctd_subnets`](#acctd_subnets)
+* [`acctd_groups`](#acctd_groups)
+* [`acctd_users`](#acctd_users)
+* [`dev_subnets`](#dev_subnets)
+* [`dev_groups`](#dev_groups)
+* [`dev_users`](#dev_users)
+
+##### <a name="acctd_subnets"></a>`acctd_subnets`
+
+Data type: `Any`
+
+List of subnets that acctd can ssh from
+
+##### <a name="acctd_groups"></a>`acctd_groups`
+
+Data type: `Any`
+
+List of groups that are allowed for acctd ssh access
+
+##### <a name="acctd_users"></a>`acctd_users`
+
+Data type: `Any`
+
+List of users that are allowed for acctd ssh access
+
+##### <a name="dev_subnets"></a>`dev_subnets`
+
+Data type: `Any`
+
+List of subnets that developer service users can ssh from
+
+##### <a name="dev_groups"></a>`dev_groups`
+
+Data type: `Any`
+
+List of developer service groups that are allowed for ssh access
+
+##### <a name="dev_users"></a>`dev_users`
+
+Data type: `Any`
+
+List of developer service users that are allowed for ssh access
+
 ### <a name="profile_iddsusers"></a>`profile_idds::users`
 
 Configure IDDS service users
@@ -64,4 +137,24 @@ Configure IDDS service users
 ```puppet
 include profile_idds::users
 ```
+
+## Functions
+
+### <a name="profile_iddsadd_firewall_entries"></a>`profile_idds::add_firewall_entries`
+
+Type: Puppet Language
+
+The profile_idds::add_firewall_entries function.
+
+#### `profile_idds::add_firewall_entries(Hash $address_hash)`
+
+The profile_idds::add_firewall_entries function.
+
+Returns: `Any`
+
+##### `address_hash`
+
+Data type: `Hash`
+
+
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,1 +1,27 @@
---- {}
+---
+profile_idds::ssh::acctd_subnets:
+  - "127.0.0.1"
+
+profile_idds::ssh::acctd_groups:
+  - "acctd"
+
+profile_idds::ssh::acctd_users:
+  - "acctd"
+
+profile_idds::ssh::dev_subnets:
+  - "141.142.146.0/24"  # NCSA VPN
+  - "141.142.197.4"     # idds-vm.ncsa.illinois.edu
+  - "141.142.197.5"     # idds-prod.ncsa.illinois.edu
+  - "141.142.197.6"     # idds-test.ncsa.illinois.edu
+  - "141.142.197.8"     # idds-vm-cpond.ncsa.illinois.edu CAN REMOVE
+  - "141.142.197.9"     # idds-prod-backup.ncsa.illinois.edu
+  - "141.142.197.12"    # idds-vm-speckins.ncsa.illinois.edu CAN REMOVE
+  - "141.142.197.14"    # idds-vm-scontre2.ncsa.illinois.edu CAN REMOVE
+
+profile_idds::ssh::dev_groups:
+  - "deploy"
+  - "git"
+
+profile_idds::ssh::dev_users:
+  - "deploy"
+  - "git"

--- a/functions/add_firewall_entries.pp
+++ b/functions/add_firewall_entries.pp
@@ -1,0 +1,35 @@
+# Add firewall entries specified as either cidr's or IP ranges for the given port.
+
+function profile_idds::add_firewall_entries(
+  Hash $address_hash,
+  )
+{
+  $port = $address_hash['PORT']
+  $port_name = $address_hash['NAME']
+  $cidr = ''
+
+  $address_hash.each | $source_name, $cidr |
+  {
+    # If the address contains a dash it is a range.
+    if $source_name == 'PORT' {
+
+    } elsif $source_name == 'NAME' {
+
+    } elsif $cidr =~ /-/ {
+        firewall { "${port} ALLOW ${port_name} FROM range ${source_name}":
+          proto     => tcp,
+          dport     => $port,
+          src_range => $cidr,
+          action    => accept,
+        }
+
+    } else {
+        firewall { "${port} ALLOW ${port_name} FROM ${source_name}":
+          proto  => tcp,
+          dport  => $port,
+          source => $cidr,
+          action => accept,
+        }
+    }
+  }
+}

--- a/manifests/firewall.pp
+++ b/manifests/firewall.pp
@@ -1,15 +1,18 @@
-# Set up the firewall for the server.
-# The defaults below can be overridden inside Foreman.
-
+# @summary Set up the firewall for the server
+#
+# @param firewall_hash
+#   The parameter is a hash of hashes.
+#   Each contained hash should start with 2 entries: "NAME' and 'PORT'.
+#
+# @example
+#   include profile_idds::firewall
 class profile_idds::firewall (
-
-  # The parameter is a hash of hashes.
-  # Each contained hash should have 2 entries 'CIDR' and "NAME'.
-
   Hash $firewall_hash,
 ) {
+
   $firewall_hash.each | $tag, $sub_hash |
   {
-    common::add_firewall_entries($sub_hash)
+    profile_idds::add_firewall_entries($sub_hash)
   }
+
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,7 +5,8 @@
 class profile_idds {
 
   include profile_idds::firewall
-  include profile_idds::users
   include profile_idds::services
+  include profile_idds::ssh
+  include profile_idds::users
 
 }

--- a/manifests/ssh.pp
+++ b/manifests/ssh.pp
@@ -1,0 +1,78 @@
+# @summary Allow ssh for service type accounts
+# 
+# @param acctd_subnets
+#   List of subnets that acctd can ssh from
+#
+# @param acctd_groups
+#   List of groups that are allowed for acctd ssh access
+#
+# @param acctd_users
+#   List of users that are allowed for acctd ssh access
+# 
+# @param dev_subnets
+#   List of subnets that developer service users can ssh from
+#
+# @param dev_groups
+#   List of developer service groups that are allowed for ssh access
+#
+# @param dev_users
+#   List of developer service users that are allowed for ssh access
+#
+# @example
+#   include profile_idds::ssh
+class profile_idds::ssh (
+  $acctd_subnets,
+  $acctd_groups,
+  $acctd_users,
+  $dev_subnets,
+  $dev_users,
+  $dev_groups,
+){
+
+  $params = {
+    'PubkeyAuthentication'  => 'yes',
+    'AuthenticationMethods' => 'publickey',
+    'Banner'                => 'none',
+    'X11Forwarding'         => 'no',
+  }
+
+  ::sshd::allow_from{ 'sshd allow acctd access from acctd clients':
+    hostlist                => $acctd_subnets,
+    groups                  => $acctd_groups,
+    users                   => $acctd_users,
+    additional_match_params => $params,
+  }
+
+  ::sshd::allow_from{ 'sshd allow developer service users access from dev nodes':
+    hostlist                => $dev_subnets,
+    groups                  => $dev_groups,
+    users                   => $dev_users,
+    additional_match_params => $params,
+  }
+
+
+  ## IF $dev_groups CONTAINS GROUP git
+  if ( 'git' in $dev_groups ) {
+    # ALSO NEED access.conf ENTRY FOR ORIGIN 'ALL EXCEPT LOCAL'
+    # pam_access DOES NOT ALLOW FOR 'ALL EXCEPT LOCAL' SO USING 'ALL'
+    pam_access::entry { 'Allow group git access from ALL':
+      group      => 'git',
+      origin     => 'ALL',
+      permission => '+',
+      position   => '-1',
+    }
+  }
+  ## IF $dev_users CONTAINS USER git
+  if ( 'git' in $dev_users ) {
+    # ALSO NEED access.conf ENTRY FOR ORIGIN 'ALL EXCEPT LOCAL'
+    # pam_access DOES NOT ALLOW FOR 'ALL EXCEPT LOCAL' SO USING 'ALL'
+    pam_access::entry { 'Allow user git access from ALL':
+      user       => 'git',
+      origin     => 'ALL',
+      permission => '+',
+      position   => '-1',
+    }
+  }
+
+}
+

--- a/spec/classes/ssh_spec.rb
+++ b/spec/classes/ssh_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'profile_idds::ssh' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile }
+    end
+  end
+end

--- a/spec/functions/add_firewall_entries_spec.rb
+++ b/spec/functions/add_firewall_entries_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'profile_idds::add_firewall_entries' do
+  # please note that these tests are examples only
+  # you will need to replace the params and return value
+  # with your expectations
+  it { is_expected.to run.with_params(2).and_return(4) }
+  it { is_expected.to run.with_params(4).and_return(8) }
+  it { is_expected.to run.with_params(nil).and_raise_error(StandardError) }
+end


### PR DESCRIPTION
- Move add_firewall_entries to this class
- Add ssh class and parameters

See https://jira.ncsa.illinois.edu/browse/ASDPLNG-142
NOTE: This PR does not address all technical debt. Its focus is just to get the IDDS profile functioning in NCSA's standardized Control Repo environments.

This is currently being tested on the following hosts:
```
idds-prod-backup
idds-test
idds-vm-cpond
idds-vm-scontre2
idds-vm-speckins
idds-vm
```
