### PR TITLE
SVC-4551: Remove idds-vm* hosts

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -10,13 +10,9 @@ profile_idds::ssh::acctd_users:
 
 profile_idds::ssh::dev_subnets:
   - "141.142.146.0/24"  # NCSA VPN
-  - "141.142.197.4"     # idds-vm.ncsa.illinois.edu
   - "141.142.197.5"     # idds-prod.ncsa.illinois.edu
   - "141.142.197.6"     # idds-test.ncsa.illinois.edu
-  - "141.142.197.8"     # idds-vm-cpond.ncsa.illinois.edu CAN REMOVE
   - "141.142.197.9"     # idds-prod-backup.ncsa.illinois.edu
-  - "141.142.197.12"    # idds-vm-speckins.ncsa.illinois.edu CAN REMOVE
-  - "141.142.197.14"    # idds-vm-scontre2.ncsa.illinois.edu CAN REMOVE
 
 profile_idds::ssh::dev_groups:
   - "deploy"


### PR DESCRIPTION
See https://jira.ncsa.illinois.edu/browse/SVC-4551

This is being tested on:
- `idds-prod-backup`

(Note that /etc/ssh/sshd_config match blocks & /etc/security/access.conf need some manual cleanup and recreation by Puppet. Puppet doesn't clean up old settings in those currently.)