### PR TITLE
SECURITY-1357: idds-prod security vetting

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -16,8 +16,6 @@ profile_idds::ssh::dev_subnets:
 
 profile_idds::ssh::dev_groups:
   - "deploy"
-  - "git"
 
 profile_idds::ssh::dev_users:
   - "deploy"
-  - "git"

--- a/manifests/ssh.pp
+++ b/manifests/ssh.pp
@@ -50,27 +50,4 @@ class profile_idds::ssh (
     additional_match_params => $params,
   }
 
-  ## IF $dev_groups CONTAINS GROUP git
-  if ( 'git' in $dev_groups ) {
-    # ALSO NEED access.conf ENTRY FOR ORIGIN 'ALL EXCEPT LOCAL'
-    # pam_access DOES NOT ALLOW FOR 'ALL EXCEPT LOCAL' SO USING 'ALL'
-    pam_access::entry { 'Allow group git access from ALL':
-      group      => 'git',
-      origin     => 'ALL',
-      permission => '+',
-      position   => '-1',
-    }
-  }
-  ## IF $dev_users CONTAINS USER git
-  if ( 'git' in $dev_users ) {
-    # ALSO NEED access.conf ENTRY FOR ORIGIN 'ALL EXCEPT LOCAL'
-    # pam_access DOES NOT ALLOW FOR 'ALL EXCEPT LOCAL' SO USING 'ALL'
-    pam_access::entry { 'Allow user git access from ALL':
-      user       => 'git',
-      origin     => 'ALL',
-      permission => '+',
-      position   => '-1',
-    }
-  }
-
 }

--- a/manifests/users.pp
+++ b/manifests/users.pp
@@ -36,6 +36,26 @@ class profile_idds::users {
     shell          => '/bin/bash',
     system         => 'true'
   }
+  group { 'grp_202':
+    ensure     => 'present',
+    name       => 'grp_202',
+    forcelocal => true,
+    gid        => '202',
+  }
+  user { 'postgres':
+    ensure         => 'present',
+    name           => 'postgres',
+    forcelocal     => true,
+    gid            => '202',
+    home           => '/home/postgres',
+    managehome     => false,
+    #managehome     => true,
+    password       => '!!',
+    purge_ssh_keys => 'false',
+    shell          => '/sbin/nologin',
+    #system         => 'true'
+    uid            => '54048',
+  }
 
   # ALLOW USERS TO RUN CRON
   pam_access::entry { 'amie-cron':
@@ -54,6 +74,9 @@ class profile_idds::users {
     mode   => '0750'
   }
 
+  ## WHY IS THE FOLLOWING HERE?          - wglick 2022-01-20
+  ## - THE postgres USER CANNOT SSH INTO ANY IDDS SERVERS
+  ## - GUESS IT COULD SSH FROM THE IDDS SERVER, BUT NOT CONVINCED IT NEEDS TO
   file {'/home/postgres/.ssh':
     ensure => 'directory',
     owner  => 'postgres',
@@ -61,16 +84,4 @@ class profile_idds::users {
     mode   => '0700'
   }
 
-  if ($facts['hostname'] != 'idds-prod') {
-    user { 'git':
-      ensure         => 'present',
-      name           => 'git',
-      home           => '/home/git',
-      managehome     => 'true',
-      password       => '!!',
-      purge_ssh_keys => 'false',
-      shell          => '/bin/bash',
-      system         => 'true'
-    }
-  }
 }


### PR DESCRIPTION
```
Force add local postgres user
Force add local grp_202 group
Remove git access via ssh
```

See https://jira.ncsa.illinois.edu/browse/SECURITY-1357

This has been tested on `idds-test` and will be applied to `idds-prod` at 10a today.